### PR TITLE
[Wip] お気に入りページの作成の実装漏れ対応

### DIFF
--- a/src/app/favorites/components/RecipesGallery.tsx
+++ b/src/app/favorites/components/RecipesGallery.tsx
@@ -1,16 +1,23 @@
 import type { FC } from "react"
 
+import { NewRecipeCard } from "../my/components/NewRecipeCard"
 import type { RecipeImage } from "../type"
 import { Recipe } from "./Recipe"
 
 type RecipesGallery = {
   recipeImages: RecipeImage[]
+  hasNewRecipeCard?: boolean
 }
 
-export const RecipesGallery: FC<RecipesGallery> = ({ recipeImages }) => (
+export const RecipesGallery: FC<RecipesGallery> = ({
+  recipeImages,
+  hasNewRecipeCard,
+}) => (
   <div className="grid grid-cols-2 gap-2">
     {recipeImages.map((recipeImage) => (
       <Recipe key={recipeImage.id} recipeImage={recipeImage} imageSize={170} />
     ))}
+
+    {hasNewRecipeCard && <NewRecipeCard />}
   </div>
 )

--- a/src/app/favorites/layout.tsx
+++ b/src/app/favorites/layout.tsx
@@ -1,0 +1,43 @@
+import type { FC, ReactNode } from "react"
+
+import { ChefAvatarsCarousel } from "./components/ChefAvatarsCarousel"
+import { NewRecipesCarousel } from "./components/NewRecipesCarousel"
+import { SettingIcon } from "./components/SettingIcon"
+import { SubHeader } from "./components/SubHeader"
+import { chefImages, newRecipeImages } from "./mock"
+
+type FavoritesLayoutProps = {
+  children: ReactNode
+}
+
+const FavoritesLayout: FC<FavoritesLayoutProps> = ({ children }) => (
+  <>
+    <div className="flex items-center justify-between border-b-2 px-2 py-3">
+      {/* お気に入りの文字を中央にするため、先頭に空のdivを置く */}
+      <div />
+      <p className="font-bold ">お気に入り</p>
+      <div className="cursor-pointer">
+        <SettingIcon />
+      </div>
+    </div>
+
+    <div className="px-4">
+      <div className="py-4">
+        <SubHeader title="シェフ" />
+        <ChefAvatarsCarousel chefImages={chefImages} />
+      </div>
+
+      <div className="mt-6 py-4">
+        <SubHeader
+          title="新着レシピ"
+          link={{ href: "/new-recipes", text: "もっと見る" }}
+        />
+        <NewRecipesCarousel newRecipeImages={newRecipeImages} />
+      </div>
+
+      <div className="mt-6 py-4">{children}</div>
+    </div>
+  </>
+)
+
+export default FavoritesLayout

--- a/src/app/favorites/my/components/AddIcon.tsx
+++ b/src/app/favorites/my/components/AddIcon.tsx
@@ -1,0 +1,13 @@
+import type { FC, SVGProps } from "react"
+
+export const AddIcon: FC = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.5em"
+    height="1.5em"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path fill="#6b7280" d="M11 19v-6H5v-2h6V5h2v6h6v2h-6v6h-2Z"></path>
+  </svg>
+)

--- a/src/app/favorites/my/components/NewRecipeCard.tsx
+++ b/src/app/favorites/my/components/NewRecipeCard.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link"
+import type { FC } from "react"
+
+import { AddIcon } from "./AddIcon"
+
+export const NewRecipeCard: FC = () => (
+  <div className="mt-3 flex justify-center">
+    {/* TODO: 遷移先を新規レシピ作成ページに変更する */}
+    <Link
+      href="/favorites"
+      className="flex h-[170px] w-[170px] cursor-pointer flex-col items-center justify-center rounded-md border"
+    >
+      <p className="text-gray-500 ">新規追加</p>
+      <AddIcon />
+    </Link>
+  </div>
+)

--- a/src/app/favorites/my/page.tsx
+++ b/src/app/favorites/my/page.tsx
@@ -1,0 +1,16 @@
+import type { NextPage } from "next"
+
+import { RecipesGallery } from "../components/RecipesGallery"
+import { SubHeader } from "../components/SubHeader"
+import { myRecipeImages } from "../mock"
+
+const Page: NextPage = () => (
+  <>
+    <SubHeader
+      title="マイレシピ"
+      link={{ href: "/favorites", text: "お気に入りレシピを見る" }}
+    />
+    <RecipesGallery recipeImages={myRecipeImages} hasNewRecipeCard />
+  </>
+)
+export default Page

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,46 +1,16 @@
-import { ChefAvatarsCarousel } from "./components/ChefAvatarsCarousel"
-import { NewRecipesCarousel } from "./components/NewRecipesCarousel"
+import type { NextPage } from "next"
+
 import { RecipesGallery } from "./components/RecipesGallery"
-import { SettingIcon } from "./components/SettingIcon"
 import { SubHeader } from "./components/SubHeader"
-import { chefImages, myRecipeImages, newRecipeImages } from "./mock"
+import { myRecipeImages } from "./mock"
 
-const Page = () => (
+const Page: NextPage = () => (
   <>
-    <div className="flex items-center justify-between border-b-2 px-2 py-3">
-      {/* お気に入りの文字を中央にするため、先頭に空のdivを置く */}
-      <div />
-      <p className="font-bold ">お気に入り</p>
-      <div className="cursor-pointer">
-        <SettingIcon />
-      </div>
-    </div>
-
-    <div className="px-4">
-      <div className="py-4">
-        <SubHeader title="シェフ" />
-        <ChefAvatarsCarousel chefImages={chefImages} />
-      </div>
-
-      <div className="mt-6 py-4">
-        {/* TODO: 遷移先の修正。一旦、同じページへの遷移とする */}
-        <SubHeader
-          title="新着レシピ"
-          link={{ href: "/favorites", text: "もっと見る" }}
-        />
-        <NewRecipesCarousel newRecipeImages={newRecipeImages} />
-      </div>
-
-      <div className="mt-6 py-4">
-        {/* TODO: 遷移先の修正。一旦、同じページへの遷移とする */}
-        <SubHeader
-          title="マイレシピを見る"
-          link={{ href: "/favorites", text: "マイレシピを見る" }}
-        />
-        <RecipesGallery recipeImages={myRecipeImages} />
-      </div>
-    </div>
+    <SubHeader
+      title="お気に入りレシピ"
+      link={{ href: "/favorites/my", text: "マイレシピをみる" }}
+    />
+    <RecipesGallery recipeImages={myRecipeImages} />
   </>
 )
-
 export default Page

--- a/src/app/new-recipes/components/BackIcon.tsx
+++ b/src/app/new-recipes/components/BackIcon.tsx
@@ -1,0 +1,16 @@
+import type { FC, SVGProps } from "react"
+
+export const BackIcon: FC = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.2em"
+    height="1.2em"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path
+      fill="#374151"
+      d="m12 20l-8-8l8-8l1.425 1.4l-5.6 5.6H20v2H7.825l5.6 5.6L12 20Z"
+    ></path>
+  </svg>
+)

--- a/src/app/new-recipes/page.tsx
+++ b/src/app/new-recipes/page.tsx
@@ -1,0 +1,24 @@
+import type { NextPage } from "next"
+import Link from "next/link"
+
+// TODO: RecipesGallery(仮)はfavoritesディレクトリではなく共通コンポーネントになるはずなので修正する。
+import { RecipesGallery } from "../favorites/components/RecipesGallery"
+import { newRecipeImages } from "../favorites/mock"
+import { BackIcon } from "./components/BackIcon"
+
+const Page: NextPage = () => (
+  <>
+    <div className="flex items-center space-x-2 border-b-2 px-4 py-3">
+      <Link href="/favorites">
+        <BackIcon />
+      </Link>
+      <p className="font-bold">新着レシピ</p>
+    </div>
+
+    <div className="px-4">
+      <RecipesGallery recipeImages={newRecipeImages} />
+    </div>
+  </>
+)
+
+export default Page


### PR DESCRIPTION
[issue](https://github.com/qin-team-recipe/02-frontend/issues/11)

![スクリーンショット 2023-06-18 11 23 25](https://github.com/qin-team-recipe/02-frontend/assets/63405154/d289fdd5-8c5b-4258-8c1c-f871aff72000)

メモ：上記が今回実装したマイレシピの部分。だた、6/17の仕様変更アーカイブを見ると、マイレシピ部分が大きく変更ありそうなので、Wip状態のままにしておく。